### PR TITLE
Sort manifest and group jumpers in a group

### DIFF
--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -176,7 +176,7 @@ func (c *Controller) Refresh() (bool, error) {
 			if rigName, ok := memberData["rig_name"].(string); ok {
 				primaryJumper.RigName = rigName
 			}
-			if groupName, ok := memberData["group_name"].(string); ok {
+			if groupName, ok := memberData["group_number"].(string); ok {
 				if x := strings.LastIndexByte(groupName, '-'); x != -1 {
 					groupName = groupName[:x]
 				}
@@ -213,7 +213,7 @@ func (c *Controller) Refresh() (bool, error) {
 				if rigName, ok := memberData["rig_name"].(string); ok {
 					jumper.RigName = rigName
 				}
-				if groupName, ok := memberData["group_name"].(string); ok {
+				if groupName, ok := memberData["group_number"].(string); ok {
 					if x := strings.LastIndexByte(groupName, '-'); x != -1 {
 						groupName = groupName[:x]
 					}

--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/jumptown-skydiving/manifest-server/pkg/decode"
 	"github.com/jumptown-skydiving/manifest-server/pkg/settings"
@@ -25,6 +26,23 @@ const (
 	burbleManifestURL = burbleBaseURL + "/ajax_dzm2_frontend_jumpermanifestpublic"
 	burbleNumColumns  = 6 // # columns to ask Burble for
 )
+
+func parseGroupName(s string) string {
+	// Strip off suffixes of the form '-##'
+	for {
+		x := strings.LastIndexByte(s, '-')
+		if x == -1 {
+			break
+		}
+		for _, c := range s[x+1:] {
+			if !unicode.IsDigit(c) {
+				return s
+			}
+		}
+		s = s[:x]
+	}
+	return s
+}
 
 type Controller struct {
 	settings    *settings.Settings
@@ -176,11 +194,8 @@ func (c *Controller) Refresh() (bool, error) {
 			if rigName, ok := memberData["rig_name"].(string); ok {
 				primaryJumper.RigName = rigName
 			}
-			if groupName, ok := memberData["group_number"].(string); ok {
-				if x := strings.LastIndexByte(groupName, '-'); x != -1 {
-					groupName = groupName[:x]
-				}
-				primaryJumper.GroupName = groupName
+			if gn, ok := memberData["group_number"].(string); ok {
+				primaryJumper.GroupName = parseGroupName(gn)
 			}
 			switch memberData["type"].(string) {
 			case "Sport Jumper":
@@ -213,11 +228,8 @@ func (c *Controller) Refresh() (bool, error) {
 				if rigName, ok := memberData["rig_name"].(string); ok {
 					jumper.RigName = rigName
 				}
-				if groupName, ok := memberData["group_number"].(string); ok {
-					if x := strings.LastIndexByte(groupName, '-'); x != -1 {
-						groupName = groupName[:x]
-					}
-					jumper.GroupName = groupName
+				if gn, ok := memberData["group_number"].(string); ok {
+					jumper.GroupName = parseGroupName(gn)
 				}
 				primaryJumper.AddGroupMember(jumper)
 			}
@@ -238,7 +250,7 @@ func (c *Controller) Refresh() (bool, error) {
 		// unique group to find groups with organizers. Any group that
 		// has no organizer is not treated as a group and all members
 		// are added to the manifest individually.
-		l.SportJumpers = make([]*Jumper, 0)
+		l.SportJumpers = l.SportJumpers[:0]
 	outerLoop:
 		for _, members := range groupNames {
 			for _, member := range members {

--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -227,17 +227,18 @@ func (c *Controller) Refresh() (bool, error) {
 		// jumpers that are in the same group.
 		groupNames := make(map[string][]*Jumper)
 		for _, j := range l.SportJumpers {
+			groupName := j.GroupName
 			if j.GroupName == "" {
-				continue
+				groupName = j.Name
 			}
-			groupNames[j.GroupName] = append(groupNames[j.GroupName], j)
+			groupNames[groupName] = append(groupNames[groupName], j)
 		}
 
 		// Empty the SportJumpers list to rebuild it. Iterate over each
 		// unique group to find groups with organizers. Any group that
 		// has no organizer is not treated as a group and all members
 		// are added to the manifest individually.
-		l.SportJumpers = l.SportJumpers[:]
+		l.SportJumpers = make([]*Jumper, 0)
 	outerLoop:
 		for _, members := range groupNames {
 			for _, member := range members {
@@ -252,7 +253,7 @@ func (c *Controller) Refresh() (bool, error) {
 					}
 				}
 				sort.Sort(JumpersByName(organizer.GroupMembers))
-				break outerLoop
+				continue outerLoop
 			}
 			l.SportJumpers = append(l.SportJumpers, members...)
 		}

--- a/pkg/burble/model.go
+++ b/pkg/burble/model.go
@@ -33,7 +33,7 @@ func NewJumper(id int64, name, shortName string) *Jumper {
 		j.ShortName = "Video"
 		j.IsVideographer = true
 	}
-	if jump == "organizer" {
+	if jump == "organizer" || jump == "student org" {
 		j.IsOrganizer = true
 	}
 

--- a/pkg/burble/model.go
+++ b/pkg/burble/model.go
@@ -9,11 +9,13 @@ type Jumper struct {
 	Name           string    `json:"name"`
 	ShortName      string    `json:"short_name"`
 	RigName        string    `json:"rig_name"`
+	GroupName      string    `json:"group_name"`
+	GroupMembers   []*Jumper `json:"group_members"`
 	IsInstructor   bool      `json:"is_instructor"`
 	IsTandem       bool      `json:"is_tandem"`
 	IsStudent      bool      `json:"is_student"`
 	IsVideographer bool      `json:"is_videographer"`
-	GroupMembers   []*Jumper `json:"group_members"`
+	IsOrganizer    bool      `json:"is_organizer"`
 }
 
 func NewJumper(id int64, name, shortName string) *Jumper {
@@ -26,9 +28,13 @@ func NewJumper(id int64, name, shortName string) *Jumper {
 	if strings.HasPrefix(strings.ToLower(j.Name), "jm ") {
 		j.Name = strings.TrimSpace(j.Name[3:])
 	}
-	if strings.ToLower(j.ShortName) == "vs" {
+	jump := strings.ToLower(j.ShortName)
+	if jump == "vs" {
 		j.ShortName = "Video"
 		j.IsVideographer = true
+	}
+	if jump == "organizer" {
+		j.IsOrganizer = true
 	}
 
 	return j
@@ -39,6 +45,20 @@ func (j *Jumper) AddGroupMember(member *Jumper) {
 	if (j.IsTandem || j.IsStudent) && !member.IsVideographer {
 		member.IsInstructor = true
 	}
+}
+
+type JumpersByName []*Jumper
+
+func (j JumpersByName) Len() int {
+	return len(j)
+}
+
+func (j JumpersByName) Swap(a, b int) {
+	j[a], j[b] = j[b], j[a]
+}
+
+func (j JumpersByName) Less(a, b int) bool {
+	return strings.ToLower(j[a].Name) < strings.ToLower(j[b].Name)
 }
 
 type Load struct {

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -58,12 +58,17 @@ func (s *manifestServiceServer) translateJumper(j *burble.Jumper, leader *Jumper
 		color  uint32
 		prefix string
 	)
+	shortName := j.ShortName
 	if leader != nil {
 		color = leader.Color
 	} else {
 		switch {
 		case j.IsTandem:
 			color = 0xffff00 // yellow
+			if leader == nil {
+				prefix = "Tandem"
+				shortName = ""
+			}
 		case j.IsStudent || strings.HasSuffix(j.ShortName, " + Gear"):
 			color = 0x00ff00 // green
 			if strings.HasSuffix(j.ShortName, " H/P") {
@@ -78,21 +83,19 @@ func (s *manifestServiceServer) translateJumper(j *burble.Jumper, leader *Jumper
 	}
 
 	var repr string
-	if leader == nil {
-		switch {
-		case j.IsTandem:
-			repr = "Tandem: " + j.Name
-		case prefix != "":
-			shortName := j.ShortName
-			if rigName := j.RigName; rigName != "" {
-				shortName = fmt.Sprintf("%s / %s", shortName, rigName)
-			}
-			repr = fmt.Sprintf("%s: %s (%s)", prefix, j.Name, shortName)
-		default:
-			repr = fmt.Sprintf("%s (%s)", j.Name, j.ShortName)
-		}
+	if rigName := j.RigName; rigName != "" {
+		shortName = fmt.Sprintf("%s / %s", shortName, rigName)
+	}
+	if shortName != "" {
+		shortName = " (" + shortName + ")"
+	}
+	if prefix != "" {
+		repr = fmt.Sprintf("%s: %s%s", prefix, j.Name, shortName)
 	} else {
-		repr = fmt.Sprintf("\t%s (%s)", j.Name, j.ShortName)
+		repr = fmt.Sprintf("%s%s", j.Name, shortName)
+	}
+	if leader != nil {
+		repr = "\t" + repr
 	}
 
 	t := JumperType_EXPERIENCED


### PR DESCRIPTION
The old manifest data coming from Burble used to sort the jumpers, but the new data does not. Sort the jumpers by name ourselves.

When there are multiple jumpers in a group, group them like tandems/students if there is also a recognized organizer. The recognized organizer strings should be configurable, but they're hard-coded for now.