### PR TITLE
Tracking and display when jumpers are turning

### DIFF
--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -302,7 +302,7 @@ func (c *Controller) Refresh() (bool, error) {
 		thisLoad.ForEachJumper(func(thisJumper *Jumper) {
 			nextLoad.ForEachJumper(func(nextJumper *Jumper) {
 				if thisJumper.Name == nextJumper.Name {
-					thisJumper.IsTurning = true
+					nextJumper.IsTurning = true
 				}
 			})
 		})

--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -296,6 +296,18 @@ func (c *Controller) Refresh() (bool, error) {
 		loads = append(loads, &l)
 	}
 
+	for i := 0; i < len(loads)-1; i++ {
+		thisLoad := loads[i]
+		nextLoad := loads[i+1]
+		thisLoad.ForEachJumper(func(thisJumper *Jumper) {
+			nextLoad.ForEachJumper(func(nextJumper *Jumper) {
+				if thisJumper.Name == nextJumper.Name {
+					thisJumper.IsTurning = true
+				}
+			})
+		})
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/burble/model.go
+++ b/pkg/burble/model.go
@@ -4,6 +4,8 @@ package burble
 
 import "strings"
 
+type ForEachJumperFunc func(j *Jumper)
+
 type Jumper struct {
 	ID             int64     `json:"id"`
 	Name           string    `json:"name"`
@@ -16,6 +18,7 @@ type Jumper struct {
 	IsStudent      bool      `json:"is_student"`
 	IsVideographer bool      `json:"is_videographer"`
 	IsOrganizer    bool      `json:"is_organizer"`
+	IsTurning      bool      `json:"is_turning"`
 }
 
 func NewJumper(id int64, name, shortName string) *Jumper {
@@ -47,6 +50,13 @@ func (j *Jumper) AddGroupMember(member *Jumper) {
 	}
 }
 
+func (j *Jumper) ForEachGroupMember(f ForEachJumperFunc) {
+	for _, member := range j.GroupMembers {
+		f(member)
+		member.ForEachGroupMember(f)
+	}
+}
+
 type JumpersByName []*Jumper
 
 func (j JumpersByName) Len() int {
@@ -73,4 +83,19 @@ type Load struct {
 	Tandems        []*Jumper `json:"tandems"`
 	Students       []*Jumper `json:"students"`
 	SportJumpers   []*Jumper `json:"sport_jumpers"`
+}
+
+func (l *Load) ForEachJumper(f ForEachJumperFunc) {
+	for _, j := range l.Tandems {
+		f(j)
+		j.ForEachGroupMember(f)
+	}
+	for _, j := range l.Students {
+		f(j)
+		j.ForEachGroupMember(f)
+	}
+	for _, j := range l.SportJumpers {
+		f(j)
+		j.ForEachGroupMember(f)
+	}
 }

--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -94,6 +94,9 @@ func (s *manifestServiceServer) translateJumper(j *burble.Jumper, leader *Jumper
 	} else {
 		repr = fmt.Sprintf("%s%s", j.Name, shortName)
 	}
+	if j.IsTurning {
+		repr = "♻️ " + repr
+	}
 	if leader != nil {
 		repr = "\t" + repr
 	}


### PR DESCRIPTION
This does a simple comparison of one load to the next without considering call times or whether the next load is turning. If a jumper is manifested on load n and load n+1, that jumper is considered to be turning. Turning jumpers are given a ♻️ emoji before their name in the manifest