### PR TITLE
Add new options to filter and limit loads

### DIFF
--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -24,7 +24,6 @@ const (
 	burbleBaseURL     = "https://dzm.burblesoft.com"
 	burblePublicURL   = burbleBaseURL + "/jmp"
 	burbleManifestURL = burbleBaseURL + "/ajax_dzm2_frontend_jumpermanifestpublic"
-	burbleNumColumns  = 6 // # columns to ask Burble for
 )
 
 func parseGroupName(s string) string {
@@ -118,6 +117,11 @@ func (c *Controller) Refresh() (bool, error) {
 		}
 	}
 
+	// Ask Burble for the number of columns we want to display + 1
+	// Do this so that we can filter out loads older tha min call minutes,
+	// but still be able to determine which jumpers are turning.
+	burbleNumColumns := c.settings.DisplayColumns() + 1
+
 	dzid := c.settings.BurbleDropzoneID()
 	bodyString := fmt.Sprintf("aircraft=0&columns=%d&display_tandem=1&display_student=1&display_sport=1&display_menu=0&font_size=0&action=getLoads&dz_id=%d&date_format=m%%2Fd%%2FY&acl_application=Burble%%20DZM", burbleNumColumns, dzid)
 	body := bytes.NewReader([]byte(bodyString))
@@ -158,7 +162,7 @@ func (c *Controller) Refresh() (bool, error) {
 	}
 
 	sourceLoads := burbleData["loads"].([]interface{})
-	columnCount := len(sourceLoads)
+	columnCount := burbleNumColumns - 1
 	for _, rawLoadData := range sourceLoads {
 		loadData, ok := rawLoadData.(map[string]interface{})
 		if !ok {
@@ -296,6 +300,18 @@ func (c *Controller) Refresh() (bool, error) {
 		loads = append(loads, &l)
 	}
 
+	// Delete loads with CallMinutes older than our minimum setting
+	minCallMinutes := c.settings.MinCallMinutes()
+	var finalLoads []*Load
+	for _, load := range loads {
+		if int(load.CallMinutes) >= minCallMinutes {
+			finalLoads = append(finalLoads, load)
+			if len(finalLoads) >= columnCount {
+				break
+			}
+		}
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -304,8 +320,8 @@ func (c *Controller) Refresh() (bool, error) {
 		c.columnCount = columnCount
 		changed = true
 	}
-	if !reflect.DeepEqual(c.loads, loads) {
-		c.loads = loads
+	if !reflect.DeepEqual(c.loads, finalLoads) {
+		c.loads = finalLoads
 		changed = true
 	}
 

--- a/pkg/settings/defaults.go
+++ b/pkg/settings/defaults.go
@@ -32,4 +32,6 @@ var defaults = map[string]interface{}{
 var defaultOptions = Options{
 	DisplayWeather: true,
 	DisplayWinds:   true,
+	DisplayColumns: 5,
+	MinCallMinutes: -10,
 }

--- a/pkg/settings/options.go
+++ b/pkg/settings/options.go
@@ -5,6 +5,8 @@ package settings
 type Options struct {
 	DisplayWeather bool   `json:"display_weather"`
 	DisplayWinds   bool   `json:"display_winds"`
+	DisplayColumns int    `json:"display_columns"`
+	MinCallMinutes int    `json:"min_call_minutes"`
 	Message        string `json:"message"`
 }
 
@@ -24,4 +26,16 @@ func (s *Settings) DisplayWinds() bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.options.DisplayWinds
+}
+
+func (s *Settings) DisplayColumns() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.options.DisplayColumns
+}
+
+func (s *Settings) MinCallMinutes() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.options.MinCallMinutes
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -154,6 +155,16 @@ func (s *Settings) SetFromURLValues(values url.Values) bool {
 					s.update(k)
 				}
 			}
+		case reflect.Int:
+			o := fv.Int()
+			n, err := strconv.ParseInt(v[0], 0, 64)
+			if err == nil && o != n {
+				changed = true
+				fv.SetInt(n)
+				if s.update != nil {
+					s.update(k)
+				}
+			}
 		case reflect.String:
 			o := fv.String()
 			n := v[0]
@@ -241,6 +252,14 @@ const settingsHTML = `<html>
 		<div>
 			<input type="checkbox" id="DisplayWinds" onchange="change('DisplayWinds');" {{if .DisplayWinds}}checked{{end}}>
 			<label>Display winds aloft information<label>
+		</div>
+		<div>
+			<label># Manifest loads to display:<label>
+			<input type="text" id="DisplayColumns" onchange="change('DisplayColumns');" value="{{.DispalyColumns}}">
+		</div>
+		<div>
+			<label>Minimum call time to display:<label>
+			<input type="text" id="MinCallMinutes" onchange="change('MinCallMinutes');" value="{{.MinCallMinutes}}">
 		</div>
 		<div>
 			<label>Message:</label>


### PR DESCRIPTION
Two new runtime tunable options are added:
1. The number of loads to pass to the client
2. The minimum value for call minutes to pass to the client

These settings are meant to supersede the setting in Burble that controls the number of loads displayed by manifest. The server is still limited by this setting, so Burble should be set to one greater than the number configured here. Loads that have call times less than the minimum call minutes is also meant to supersede the related Burble setting.

The motivation for these changes is to help with the turning jumpers feature. Since we want turning jumpers to be marked on the load they're turning on, we must keep information about their previous load around. The server can only keep a snapshot of data from Burble, so if/when the previous load disappears from the Burble data source, we can no longer determine whether the jumper is turning or not. So, keep the previous load around longer than normal, but let it fall off the display sooner.

We can't keep information about prior loads that have disappeared from the Burble data source hanging around, because when they disappear we have no way of knowing _why_ they disappeared. We can assume, but then we'll likely get that assumption wrong some of the time, and @kdrivas1989 will be blowing up my phone with texts about things not working right 😉 