### PR TITLE
Load runtime options more carefully to preserve defaults

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -5,6 +5,7 @@ package settings
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -81,9 +82,33 @@ func (s *Settings) restore() error {
 		return err
 	}
 
-	var newOptions Options
-	if err = json.Unmarshal(dataBytes, &newOptions); err != nil {
+	var rawOptions interface{}
+	if err = json.Unmarshal(dataBytes, &rawOptions); err != nil {
 		return err
+	}
+	optionsMap, typeok := rawOptions.(map[string]interface{})
+	if !typeok {
+		return errors.New("invalid options format")
+	}
+
+	newOptions := defaultOptions
+	newOptionsValue := reflect.ValueOf(&newOptions)
+	t := reflect.TypeOf(newOptions)
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		key, ok := f.Tag.Lookup("json")
+		if !ok {
+			continue
+		}
+		if x := strings.IndexByte(key, ','); x != -1 {
+			key = key[:x]
+		}
+		value, ok := optionsMap[key]
+		if !ok {
+			continue
+		}
+		v := newOptionsValue.Elem().Field(i)
+		v.Set(reflect.ValueOf(value).Convert(v.Type()))
 	}
 
 	s.lock.Lock()


### PR DESCRIPTION
Instead of loading the `options.json` and file and using it as-is for the set of options, parse each option out individually and apply it to an options struct initialized to the set of defaults. The difference is that with the original method, adding new options to the server means they get treated as 0 regardless of the default when the server is brought up for the first time. This is not desirable, as we found out when we added new options to control the number of columns to display. The new way is much more robust