### PR TITLE
Fix for Burble's fixed broken rig_id field

### DIFF
--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -60,9 +60,12 @@ func jumperFromJSON(json map[string]interface{}) *Jumper {
 	// rig_id is inconsistent with other name/id fields in the Burble data.
 	// The field used to be rig_name until Burble did a major data revision
 	// and it became rig_id.
+	// Update: Looks like Burble fixed this at some point over the summer.
+	//         Leave all of this here for now until we can verify the fix,
+	//         but add an additional "0" check for "rig_id"
 	if rigName, ok := json["rig_name"].(string); ok && rigName != "" {
 		jumper.RigName = rigName
-	} else if rigName, ok = json["rig_id"].(string); ok && rigName != "" {
+	} else if rigName, ok = json["rig_id"].(string); ok && rigName != "" && rigName != "0" {
 		jumper.RigName = rigName
 	}
 	return jumper


### PR DESCRIPTION
Somewhere along the way, Burble introduced a regression in their data that left "rig_name" always blank, and used "rig_id" as what "rig_name" should have been. So we worked around this by using "rig_id" as "rig_name" if "rig_name" was empty. Well, it looks like Burble fixed their regression, but in doing so changed "rig_id" to "0" when "rig_name" was also blank, which is actually the right thing. Our work-around was insufficient to handle the fix, so this leaves the old work-around in for now along with a fix for the work-around to work with correct Burble data.

This was something I patched quick and dirty when the change happened during the season, but I never cleaned it up and did it right. Now it's the off-season and I don't have data to look at, but I don't want to lose the change, so this is what it is.