### PR TITLE
Make strings flagging primary jumpers as organizers configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,10 @@ server:
 
 burble:
   dzid: 417
+  organizer_strings:
+    - "organizer"
+    - "student org"
+    - "aff - evaluator"
 
 metar:
   enabled: true

--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -164,6 +164,7 @@ func (c *Controller) Refresh() (bool, error) {
 		return false, errors.New("Burble data is missing load information")
 	}
 
+	organizerStrings := c.settings.OrganizerStrings()
 	sourceLoads := burbleData["loads"].([]interface{})
 	columnCount := burbleNumColumns - 1
 	for _, rawLoadData := range sourceLoads {
@@ -218,6 +219,15 @@ func (c *Controller) Refresh() (bool, error) {
 			members := rawGroupData.([]interface{})
 			memberData := members[0].(map[string]interface{})
 			primaryJumper := jumperFromJSON(memberData)
+
+			jump := strings.ToLower(primaryJumper.ShortName)
+			for _, o := range organizerStrings {
+				if jump == o {
+					primaryJumper.IsOrganizer = true
+					break
+				}
+			}
+
 			switch memberData["type"].(string) {
 			case "Sport Jumper":
 				l.SportJumpers = append(l.SportJumpers, primaryJumper)

--- a/pkg/burble/model.go
+++ b/pkg/burble/model.go
@@ -36,9 +36,6 @@ func NewJumper(id int64, name, shortName string) *Jumper {
 		j.ShortName = "Video"
 		j.IsVideographer = true
 	}
-	if jump == "organizer" || jump == "student org" {
-		j.IsOrganizer = true
-	}
 
 	return j
 }

--- a/pkg/settings/burble.go
+++ b/pkg/settings/burble.go
@@ -2,6 +2,21 @@
 
 package settings
 
+import "strings"
+
 func (s *Settings) BurbleDropzoneID() int {
 	return s.config.GetInt("burble.dzid")
+}
+
+func (s *Settings) OrganizerStrings() []string {
+	o := s.config.GetStringSlice("burble.organizer_strings")
+	if len(o) == 0 {
+		o = []string{"organizer"}
+	} else {
+		lo := make([]string, len(o))
+		for i := range o {
+			lo[i] = strings.ToLower(o[i])
+		}
+	}
+	return o
 }


### PR DESCRIPTION
Make the strings flagging primary jumpers as organizers configurable. At least for now they are not runtime options that can be changed while the server is running, but they're configured in the server's config.yaml. This also makes a minor change having no practical effect that only primary jumpers can be flagged as organizers