### PR TITLE
Add configurable referrer code for winds aloft data

### DIFF
--- a/pkg/settings/weather.go
+++ b/pkg/settings/weather.go
@@ -14,6 +14,10 @@ func (s *Settings) WindsLongitude() string {
 	return s.config.GetString("winds.longitude")
 }
 
+func (s *Settings) WindsReferrer() string {
+	return s.config.GetString("winds.referrer")
+}
+
 func (s *Settings) METAREnabled() bool {
 	return s.config.GetBool("metar.enabled")
 }

--- a/pkg/winds/controller.go
+++ b/pkg/winds/controller.go
@@ -34,15 +34,18 @@ type Controller struct {
 	lock sync.Mutex
 }
 
+// Winds Aloft data requires a referral code from Mark Schulze. Please contact
+// him and configure the referrer code in your config.yaml
 const windsAloftURL = "https://markschulze.net/winds/winds.php?hourOffset=0"
 
 func NewController(settings *settings.Settings) *Controller {
 	latitude := settings.WindsLatitude()
 	longitude := settings.WindsLongitude()
+	referrer := settings.WindsReferrer()
 	wa := &Controller{
 		settings: settings,
-		url: fmt.Sprintf("%s&lat=%s&lon=%s", windsAloftURL, latitude,
-			longitude),
+		url: fmt.Sprintf("%s&lat=%s&lon=%s&referrer=%s", windsAloftURL,
+			latitude, longitude, referrer),
 	}
 
 	return wa


### PR DESCRIPTION
Winds aloft data now requires a referrer code to be configured in `config.yaml`.