### PR TITLE
Add missing transaction aborts on error

### DIFF
--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -620,6 +620,7 @@ func (s *manifestServiceServer) VerifySessionID(
 
 	session, err := s.app.LookupSession(ctx, tx, req.SessionId)
 	if err != nil {
+		_ = s.app.AbortDatabaseTransaction(tx)
 		sessionDeleted := false
 		if errors.Is(err, db.ErrInvalidSessionID) {
 			sessionDeleted = true
@@ -634,6 +635,7 @@ func (s *manifestServiceServer) VerifySessionID(
 
 	user, err := s.app.LookupUser(tx, session.UserID)
 	if err != nil {
+		_ = s.app.AbortDatabaseTransaction(tx)
 		return &SignInResponse{
 			ErrorMessage: fmt.Sprintf("LookupUser: %v", err),
 		}, nil


### PR DESCRIPTION
There were a couple of error conditions during active transactions that were not rolling back transactions, leaving the database in a permanently locked state, at least until the server restarted. Add the missing transaction aborts where appropriate to avoid this condition