### PR TITLE
Refresh cookies if unparseable data received from Burble

### DIFF
--- a/pkg/burble/controller.go
+++ b/pkg/burble/controller.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -158,12 +159,24 @@ func (c *Controller) Refresh() (bool, error) {
 
 	var rawBurbleData interface{}
 	if err = json.Unmarshal(data, &rawBurbleData); err != nil {
+		// If we get unparseable data, dump it to a file so we can
+		// review it later to see what the problem is.
+		_ = ioutil.WriteFile("burble.json", data, 0644)
+		if err = c.RefreshCookies(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error refreshing cookies: %v\n", err)
+		}
 		return false, err
 	}
 
 	var loads []*Load
 	burbleData := rawBurbleData.(map[string]interface{})
 	if _, ok := burbleData["loads"]; !ok {
+		// If we get unparseable data, dump it to a file so we can
+		// review it later to see what the problem is.
+		_ = ioutil.WriteFile("burble.json", data, 0644)
+		if err = c.RefreshCookies(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error refreshing cookies: %v\n", err)
+		}
 		return false, errors.New("Burble data is missing load information")
 	}
 


### PR DESCRIPTION
It's long been a problem where the server periodically loses the ability to pull data from Burble. I'm assuming that this is because the cookies necessary expire at some point, but whenever it's happened it's always been easier to just restart the server and I've never really been able to debug the real problem. This is a fix that just assumes that expired cookies are the problem and so refreshes them and tries again. It also logs the bad data received so it can be looked reviewed later. So far the only data I've seen logged is a 502 (Bad Gateway) error from the remote server, so nothing we can really do about it. The cookie refresh doesn't hurt in this case.