### PR TITLE
Add support for grouping jumpers by jump type

### DIFF
--- a/pkg/settings/burble.go
+++ b/pkg/settings/burble.go
@@ -2,7 +2,11 @@
 
 package settings
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"strings"
+)
 
 func (s *Settings) BurbleDropzoneID() int {
 	return s.config.GetInt("burble.dzid")
@@ -19,4 +23,42 @@ func (s *Settings) OrganizerStrings() []string {
 		}
 	}
 	return o
+}
+
+type GroupByJumpType struct {
+	JumpType        string
+	ManifestHeading string
+}
+
+func (s *Settings) GroupByJumpTypes() []GroupByJumpType {
+	jumptype_groups := s.config.Get("burble.jumptype_groups")
+	groups, ok := jumptype_groups.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	result := make([]GroupByJumpType, 0, len(groups))
+	for _, g := range groups {
+		gg, ggok := g.(map[string]interface{})
+		if !ggok {
+			continue
+		}
+
+		typ, tok := gg["type"].(string)
+		if !tok {
+			fmt.Fprintf(os.Stderr, "error: missing type for burble.jumptype_group\n")
+			continue
+		}
+
+		heading, hok := gg["group"].(string)
+		if !hok {
+			heading = strings.ToTitle(typ)
+		}
+		r := GroupByJumpType{
+			JumpType:        typ,
+			ManifestHeading: heading,
+		}
+		result = append(result, r)
+	}
+	return result
 }


### PR DESCRIPTION
Add support for grouping jumpers by jump type. The jump type is a field that comes from Burble. Each jump type grouping is configurable with a specification for the name to appear in the group header. This is similar to organizer groupings, except that there is no organizer and the configured name appears outdented with the group members indented below it